### PR TITLE
Fix PostgreSQL compatibility and update UMLS linkout

### DIFF
--- a/evaluation_app/evaluate.py
+++ b/evaluation_app/evaluate.py
@@ -225,7 +225,8 @@ def calculate_confusion_matrix(model):
     conn, cursor, paramstyle, q, db_path = get_db_connection()
     # Get all indices where medmentions has a result
     sql = q('''
-        SELECT mm.idx, mm.identifier as medmentions_id, m.identifier as model_id, m.rowid as model_row_exists
+        SELECT mm.idx, mm.identifier as medmentions_id, m.identifier as model_id,
+               CASE WHEN m.idx IS NOT NULL THEN 1 ELSE 0 END as model_row_exists
         FROM results mm
         LEFT JOIN results m ON m.idx = mm.idx AND m.model = ?
         WHERE mm.model = 'medmentions' AND mm.identifier IS NOT NULL
@@ -234,7 +235,7 @@ def calculate_confusion_matrix(model):
     rows = cursor.fetchall()
     summary = {'match': 0, 'disagree': 0, 'null': 0}
     for idx, medmentions_id, model_id, model_row_exists in rows:
-        if model_row_exists is None:
+        if model_row_exists == 0:
             # No row for the model: skip
             continue
         if model_id is None:
@@ -313,19 +314,26 @@ def confusion_matrix():
         selected_model = app.config['MODEL']
     model = selected_model
     conn, cursor, paramstyle, q, db_path = get_db_connection()
-    # Get all rows for this model, with medmentions
-    sql = q('''
-        SELECT r.idx,
-               mm.identifier as medmentions_id,
-               m.identifier as model_id
-        FROM results r
-        LEFT JOIN results mm ON mm.idx = r.idx AND mm.model = 'medmentions'
-        LEFT JOIN results m ON m.idx = r.idx AND m.model = ?
-        WHERE r.model = 'medmentions' OR r.model = ?
-        GROUP BY r.idx
+    # Get all distinct indices first
+    sql_indices = q('''
+        SELECT DISTINCT idx FROM results WHERE model = 'medmentions' OR model = ?
     ''')
-    cursor.execute(sql, (model, model))
-    rows = cursor.fetchall()
+    cursor.execute(sql_indices, (model,))
+    indices = [row[0] for row in cursor.fetchall()]
+
+    rows = []
+    for idx in indices:
+        # Get medmentions identifier for this idx
+        cursor.execute(q('SELECT identifier FROM results WHERE idx = ? AND model = \'medmentions\''), (idx,))
+        mm_row = cursor.fetchone()
+        medmentions_id = mm_row[0] if mm_row else None
+
+        # Get model identifier for this idx
+        cursor.execute(q('SELECT identifier FROM results WHERE idx = ? AND model = ?'), (idx, model))
+        m_row = cursor.fetchone()
+        model_id = m_row[0] if m_row else None
+
+        rows.append((idx, medmentions_id, model_id))
     # Build confusion matrix
     # Rows: medmentions (present, null)
     # Columns: model (agrees, disagrees, is null)
@@ -352,19 +360,26 @@ def confusion_matrix():
 
 def calculate_confusion_matrix_vs_assessment(model, assessor):
     conn, cursor, paramstyle, q, db_path = get_db_connection()
-    # Get all idx with medmentions and model results
-    sql = q('''
-        SELECT r.idx,
-               mm.identifier as medmentions_id,
-               m.identifier as model_id
-        FROM results r
-        LEFT JOIN results mm ON mm.idx = r.idx AND mm.model = 'medmentions'
-        LEFT JOIN results m ON m.idx = r.idx AND m.model = ?
-        WHERE r.model = 'medmentions' OR r.model = ?
-        GROUP BY r.idx
+    # Get all distinct indices first
+    sql_indices = q('''
+        SELECT DISTINCT idx FROM results WHERE model = 'medmentions' OR model = ?
     ''')
-    cursor.execute(sql, (model, model))
-    rows = cursor.fetchall()
+    cursor.execute(sql_indices, (model,))
+    indices = [row[0] for row in cursor.fetchall()]
+
+    rows = []
+    for idx in indices:
+        # Get medmentions identifier for this idx
+        cursor.execute(q('SELECT identifier FROM results WHERE idx = ? AND model = \'medmentions\''), (idx,))
+        mm_row = cursor.fetchone()
+        medmentions_id = mm_row[0] if mm_row else None
+
+        # Get model identifier for this idx
+        cursor.execute(q('SELECT identifier FROM results WHERE idx = ? AND model = ?'), (idx, model))
+        m_row = cursor.fetchone()
+        model_id = m_row[0] if m_row else None
+
+        rows.append((idx, medmentions_id, model_id))
     # Confusion matrix: rows=medmentions (True, False, Unsure), cols=model (True, False, Unsure, Null)
     matrix = {
         'True':    {'True': 0, 'False': 0, 'Unsure': 0, 'Null': 0},

--- a/evaluation_app/templates/abstract.html
+++ b/evaluation_app/templates/abstract.html
@@ -401,7 +401,7 @@
                                 {%- elif prefix == 'HP' -%}
                                     <a href="http://purl.obolibrary.org/obo/HP_{{ local_id }}" target="_blank" rel="noopener" class="pmid-link">{{ info.identifier }}</a>
                                 {%- elif prefix == 'UMLS' -%}
-                                    <a href="https://uts.nlm.nih.gov/uts/umls/concept/{{ local_id }}" target="_blank" rel="noopener" class="pmid-link">{{ info.identifier }}</a>
+                                    <a href="https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncim/{{ local_id }}" target="_blank" rel="noopener" class="pmid-link">{{ info.identifier }}</a>
                                 {%- elif prefix == 'NCIT' -%}
                                     <a href="https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/{{ local_id }}" target="_blank" rel="noopener" class="pmid-link">{{ info.identifier }}</a>
                                 {%- elif prefix == 'ENSEMBL' -%}
@@ -478,7 +478,7 @@
             'CHEBI': 'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:' + localId,
             'MESH': 'https://id.nlm.nih.gov/mesh/' + localId + '.html',
             'HP': 'http://purl.obolibrary.org/obo/HP_' + localId,
-            'UMLS': 'https://uts.nlm.nih.gov/uts/umls/concept/' + localId,
+            'UMLS': 'https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncim/' + localId,
             'NCIT': 'https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncit/' + localId,
             'ENSEMBL': 'https://useast.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=' + localId,
             'HGNC': 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/' + localId,


### PR DESCRIPTION
## Summary
- Update UMLS linkout URL to EVS Explore NCIM interface
- Fix PostgreSQL compatibility issues in evaluation app

## Changes
1. **UMLS Linkout Update**: Changed from `https://uts.nlm.nih.gov/uts/umls/concept/` to `https://evsexplore.semantics.cancer.gov/evsexplore/concept/ncim/` for better UMLS concept browsing
2. **PostgreSQL Compatibility Fixes**:
   - Replaced SQLite-specific `rowid` with database-agnostic `CASE WHEN` expression
   - Rewrote complex JOIN queries with GROUP BY that were causing Cartesian products and query hangs
   - Fixed GROUP BY clauses to include all non-aggregated columns as required by PostgreSQL

## Files Modified
- `evaluation_app/templates/abstract.html` - Updated UMLS linkout URL in both Jinja template and JavaScript
- `evaluation_app/evaluate.py` - Fixed database compatibility issues in confusion matrix queries

## Testing
Tested with PostgreSQL backend on run_5 data - `/results` endpoint now works without hanging.